### PR TITLE
fix debconf: unable to initialize frontend: Dialog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY sources.list /etc/apt/sources.list
 
 MAINTAINER Dennis Sänger <mail@dennis.io>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN echo '#!/bin/sh' > /usr/sbin/policy-rc.d \
 	&& echo 'exit 101' >> /usr/sbin/policy-rc.d \
 	&& chmod +x /usr/sbin/policy-rc.d \


### PR DESCRIPTION
fix issue on https://github.com/ds82/ubuntu-hardy-8.04-i386-docker/issues/1